### PR TITLE
fix: normalizando o estilo dos headings

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -45,3 +45,13 @@ input {
 input::-webkit-input-placeholder {
   opacity: 0.5;
 }
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: normal;
+  font-style: normal;
+}


### PR DESCRIPTION
Ao mandar a PR https://github.com/the-web-forest/Website/pull/111 para develop encontrei o seguinte ajuste:

Como eu mudei alguns textos de `div` para algo mais semântico, eles ficaram suscetíveis a estilização padrão de cada navegador, então adicionei uma regra no `styles/globals.css` para normalizar o estilo dos headings.

O caso que eu encontrei foi desse título no edge:

Em dev
![image](https://user-images.githubusercontent.com/24192460/222978983-482984d8-cef0-475f-ba75-16d0401f790f.png)

Em prod
![image](https://user-images.githubusercontent.com/24192460/222978985-87a14984-03b6-4800-8f7d-a6b8b6cc8ccc.png)
